### PR TITLE
Update keep-drogon-alive.p8

### DIFF
--- a/keep-drogon-alive.p8
+++ b/keep-drogon-alive.p8
@@ -483,6 +483,12 @@ function draw_death()
 end
 
 function update_win()
+if btn(4) then
+     scene = "title"
+     sfx(-1)
+     music(0)
+     _init()
+  end
 end
 
 function draw_win()


### PR DESCRIPTION
Updating the win situation 

When game over, pressing the z can function can go back to the game screen.

So the player can replay the game